### PR TITLE
Missing comma

### DIFF
--- a/kolibri_sync_extras_plugin/sync/operations.py
+++ b/kolibri_sync_extras_plugin/sync/operations.py
@@ -79,7 +79,7 @@ class BackgroundJobOperation(SyncExtrasLocalOperation):
 
         job = Job(
             call_command,
-            args=("sync_proceed_to"),
+            args=("sync_proceed_to",),
             kwargs={
                 "id": context.transfer_session.id,
                 "target_stage": target_stage,

--- a/test/sync/test_operations.py
+++ b/test/sync/test_operations.py
@@ -69,7 +69,7 @@ class BackgroundJobOperationTestCase(BaseTestCase):
         self.assertEqual(
             job.kwargs,
             {
-                "args": "sync_proceed_to",
+                "args": ("sync_proceed_to",),
                 "kwargs": {
                     "id": "def456",
                     "target_stage": "other",


### PR DESCRIPTION
Causing a problem in the job args as it was not identified as a tuple because of a missing comma